### PR TITLE
Bring the script to a working state again

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,12 @@ pip3 install -r requirements.txt
 ```
 
 ## Usage
-1) Using credentials:
-```bash
-python3 importer.py -u <spotify_username> -l <yandex_login> -p <yandex_password>
-```
-2) Using token:
+1) Using token:
 ```bash
 python3 importer.py -u <spotify_username> -t <yandex_token>
 ```
 
-3) If you don't want to import some items (likes, playlists, albums, artists) you can exclude them by specifying ignore argument, for example:
+2) If you don't want to import some items (likes, playlists, albums, artists) you can exclude them by specifying ignore argument, for example:
 ```bash
 python3 importer.py -u <spotify_username> -t <yandex_token> -i playlists albums artists
 ```

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ pip3 install -r requirements.txt
 
 ## Usage
 
-0) Register a dummy Spotify OAuth application at <https://developer.spotify.com/dashboard> and copy its client id and secret. Make sure to add `https://open.spotify.com` as the callback URL.
+0) [Register a dummy Spotify OAuth application](https://developer.spotify.com/dashboard) and add `https://open.spotify.com` as the callback URI.
 
 1) Obtain a Yandex.Music OAuth token.[^1]
 
-2) Run the script:
+2) Run the script using Client ID and Client Secret copied from your app's Spotify dashboard:
 ```bash
 python3 importer.py --id <spotify_client_id> --secret <spotify_client_secret> -u <spotify_username> -t <yandex_token>
 ```
 
-3) If you don't want to import some items (likes, playlists, albums, artists) you can exclude them by specifying the `--ignore` argument, for example:
+3) If you don't want to import some items (likes, playlists, albums, artists) you can exclude them by specifying the `-i/--ignore` argument, for example:
 ```bash
 python3 importer.py --id <spotify_client_id> --secret <spotify_client_secret> -u <spotify_username> -t <yandex_token> -i playlists albums artists
 ```

--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ pip3 install -r requirements.txt
 
 ## Usage
 
+0) Register a dummy Spotify OAuth application at <https://developer.spotify.com/dashboard> and copy its client id and secret. Make sure to add `https://open.spotify.com` as the callback URL.
+
 1) Obtain a Yandex.Music OAuth token.[^1]
 
 2) Run the script:
 ```bash
-python3 importer.py -u <spotify_username> -t <yandex_token>
+python3 importer.py --id <spotify_client_id> --secret <spotify_client_secret> -u <spotify_username> -t <yandex_token>
 ```
 
 3) If you don't want to import some items (likes, playlists, albums, artists) you can exclude them by specifying the `--ignore` argument, for example:
 ```bash
-python3 importer.py -u <spotify_username> -t <yandex_token> -i playlists albums artists
+python3 importer.py --id <spotify_client_id> --secret <spotify_client_secret> -u <spotify_username> -t <yandex_token> -i playlists albums artists
 ```
 
 [^1]: Since it's impossible to register an OAuth application with Yandex.Music access scope, you have to [reuse the token from music.yandex.ru itself](https://github.com/MarshalX/yandex-music-api/discussions/513).

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # yandex2spotify
-Simple Python script, that allow to import favorite tracks, playlists, albums and artists from Yandex.Music to Spotify
 
-## Install requirments
+A simple Python script that allows to import favorite tracks, playlists, albums, and artists from Yandex.Music to Spotify
+
+## Installation
+
 ```bash
 pip3 install -r requirements.txt
 ```
 
 ## Usage
-1) Using token:
+
+1) Obtain a Yandex.Music OAuth token.[^1]
+
+2) Run the script:
 ```bash
 python3 importer.py -u <spotify_username> -t <yandex_token>
 ```
 
-2) If you don't want to import some items (likes, playlists, albums, artists) you can exclude them by specifying ignore argument, for example:
+3) If you don't want to import some items (likes, playlists, albums, artists) you can exclude them by specifying the `--ignore` argument, for example:
 ```bash
 python3 importer.py -u <spotify_username> -t <yandex_token> -i playlists albums artists
 ```
+
+[^1]: Since it's impossible to register an OAuth application with Yandex.Music access scope, you have to [reuse the token from music.yandex.ru itself](https://github.com/MarshalX/yandex-music-api/discussions/513).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip3 install -r requirements.txt
 
 ## Usage
 
-0) [Register a dummy Spotify OAuth application](https://developer.spotify.com/dashboard) and add `https://open.spotify.com` as the callback URI.
+0) [Register a dummy Spotify OAuth application](https://developer.spotify.com/dashboard) and **add `https://open.spotify.com` as a callback URI** in its settings.
 
 1) Obtain a Yandex.Music OAuth token.[^1]
 

--- a/importer.py
+++ b/importer.py
@@ -11,8 +11,6 @@ from spotipy.exceptions import SpotifyException
 from spotipy.oauth2 import SpotifyOAuth
 from yandex_music import Client, Artist
 
-CLIENT_ID = '9b3b6782c67a4a8b9c5a6800e09edb27'
-CLIENT_SECRET = '7809b5851f1d4219963a3c0735fd5bea'
 REDIRECT_URI = 'https://open.spotify.com'
 MAX_REQUEST_RETRIES = 5
 
@@ -215,6 +213,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Creates a playlist for user')
     parser.add_argument('-u', '-s', '--spotify', required=True, help='Username at spotify.com')
 
+    spotify_oauth = parser.add_argument_group('spotify_oauth')
+    spotify_oauth.add_argument('--id', required=True, help='Client ID of your Spotify app')
+    spotify_oauth.add_argument('--secret', required=True, help='Client Secret of your Spotify app')
+
     parser.add_argument('-t', '--token', required=True, help='Token from music.yandex.com account')
 
     parser.add_argument('-i', '--ignore', nargs='+', help='Don\'t import some items',
@@ -227,8 +229,8 @@ if __name__ == '__main__':
     arguments = parser.parse_args()
 
     auth_manager = SpotifyOAuth(
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
+        client_id=arguments.id,
+        client_secret=arguments.secret,
         redirect_uri=REDIRECT_URI,
         scope='playlist-modify-public, user-library-modify, user-follow-modify, ugc-image-upload',
         username=arguments.spotify

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Pillow==8.1.1
 spotipy==2.13.0
-git+https://github.com/MarshalX/yandex-music-api@development
+yandex-music==2.0.1


### PR DESCRIPTION
(resolves https://github.com/lemonpaul/yandex2spotify/issues/30)

привет! мне понадобилась миграция в Spotify, а для этого нужно было починить скрипт, и теперь он снова работает. что поменялось:
- у `yandex-music` мало того, что дев-ветка переименовалась (а сам пакет — стабилизировался), так оно больше не умеет авторизовываться по логину и паролю (похоже, Яндекс это сам отломал), а значит, нужны инструкции по добыче OAuth-токена Музыки
- захардкоженные `CLIENT_ID` и `CLIENT_SECRET` не работают, а это значит, что теперь нужно самому регистрировать OAuth-приложение для Spotify