### PR TITLE
fix: catch notFound error during import from y.music to spotify

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -120,6 +120,9 @@ class Importer:
                 except NotFoundException as exception:
                     not_imported_section.append(exception.item_name)
                     logger.warning('NO')
+                except SpotifyException as exception:
+                    not_imported_section.append(item.title)
+                    logger.warning('NO')
 
         for chunk in chunks(spotify_items, 50):
             save_items_callback(self, chunk)

--- a/importer.py
+++ b/importer.py
@@ -120,7 +120,7 @@ class Importer:
                 except NotFoundException as exception:
                     not_imported_section.append(exception.item_name)
                     logger.warning('NO')
-                except SpotifyException as exception:
+                except SpotifyException:
                     not_imported_section.append(item.title)
                     logger.warning('NO')
 


### PR DESCRIPTION
Found a bug during migration from y.music into spotify, the script failed when trying to search the track in spotify:

y.music: https://music.yandex.ru/album/6227058/track/27532871?lang=en

spotify: https://open.spotify.com/track/1ZO8GU5YiM8lWr2PZt81z5?si=bc0854fe51a847ee

With the following traceback

<details>
<summary>traceback</summary>

```shell
2022-09-11 12:23:52,005 - ERROR - HTTP Error for GET to https://api.spotify.com/v1/search returned 404 due to Not found.
Traceback (most recent call last):
  File "/tmp/yandex2spotify/yandex2spotifyn/lib/python3.10/site-packages/spotipy/client.py", line 175, in _internal_call
    response.raise_for_status()
  File "/tmp/yandex2spotify/yandex2spotifyn/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.spotify.com/v1/search?q=Chor+Der+Deutschen+Oper+Berlin%2C+Orchester+Der+Deutschen+Oper+Berlin%2C+Rafael+Fr%C3%BChbeck+de+Burgos%2C+%D0%A0%D0%B8%D1%85%D0%B0%D1%80%D0%B4+%D0%92%D0%B0%D0%B3%D0%BD%D0%B5%D1%80+Aida%3A+Gloria+all%27+Egitto+ad+Iside&limit=10&offset=0&type=track

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/yandex2spotify/importer.py", line 242, in <module>
    Importer(spotify_client_, yandex_client_, arguments.ignore, arguments.strict_artists_search).import_all()
  File "/tmp/yandex2spotify/importer.py", line 200, in import_all
    item()
  File "/tmp/yandex2spotify/importer.py", line 168, in import_playlists
    self._add_items_to_spotify(tracks, self.not_imported[playlist.title], save_tracks_callback)
  File "/tmp/yandex2spotify/importer.py", line 118, in _add_items_to_spotify
    spotify_items.append(self._import_item(item))
  File "/tmp/yandex2spotify/importer.py", line 97, in _import_item
    found_items = handle_spotify_exception(self.spotify_client.search)(query, type=type_)[f'{type_}s']['items']
  File "/tmp/yandex2spotify/importer.py", line 48, in wrapper
    raise exception
  File "/tmp/yandex2spotify/importer.py", line 44, in wrapper
    return func(*args, **kwargs)
  File "/tmp/yandex2spotify/yandex2spotifyn/lib/python3.10/site-packages/spotipy/client.py", line 463, in search
    return self._get(
  File "/tmp/yandex2spotify/yandex2spotifyn/lib/python3.10/site-packages/spotipy/client.py", line 210, in _get
    return self._internal_call("GET", url, payload, kwargs)
  File "/tmp/yandex2spotify/yandex2spotifyn/lib/python3.10/site-packages/spotipy/client.py", line 186, in _internal_call
    raise SpotifyException(
spotipy.exceptions.SpotifyException: http status: 404, code:-1 - https://api.spotify.com/v1/search?q=Chor+Der+Deutschen+Oper+Berlin%2C+Orchester+Der+Deutschen+Oper+Berlin%2C+Rafael+Fr%C3%BChbeck+de+Burgos%2C+%D0%A0%D0%B8%D1%85%D0%B0%D1%80%D0%B4+%D0%92%D0%B0%D0%B3%D0%BD%D0%B5%D1%80+Aida%3A+Gloria+all%27+Egitto+ad+Iside&limit=10&offset=0&type=track:
 Not found.
```

</details>