### PR TITLE
Improving of migration to multiple Spotify accounts

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -242,8 +242,7 @@ if __name__ == '__main__':
         client_secret=arguments.secret,
         redirect_uri=REDIRECT_URI,
         scope='playlist-modify-public, user-library-modify, user-follow-modify, ugc-image-upload',
-        username=arguments.spotify,
-        cache_path='cache.txt'
+        username=arguments.spotify
     )
     spotify_client_ = spotipy.Spotify(auth_manager=auth_manager, requests_timeout=arguments.timeout)
 


### PR DESCRIPTION
Explicit `cache_path` parameter makes one cache file for all Spotify accounts. And if you want to successfully migrate tracks to multiple Spotify accounts, you have to remove this cache file before signing to next account. Otherwise bad request error appears.

Removing explicit `cache_path` parameter causes separate cache file for every Spotify account. As a result, tracks migration to multiple Spotify accounts becomes clearer and easier.