### PR TITLE
Fix "None" handling

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -131,11 +131,12 @@ class Importer:
             if item.available:
                 try:
                     spotify_id = self._import_item(item)
-                    if spotify_id is not None:
-                        spotify_items.append(spotify_id)
-                        logger.info('OK')
-                    else:
+                    if spotify_id is None:
                         logger.warning('Item ID is None, skipping...')
+                        continue
+                    spotify_items.append(spotify_id)
+                    logger.info('OK')
+
                 except NotFoundException as exception:
                     not_imported_section.append(exception.item_name)
                     logger.warning('NO')
@@ -143,11 +144,13 @@ class Importer:
                     not_imported_section.append(item.title)
                     logger.warning('NO')
 
-        if spotify_items:
-            for chunk in chunks(spotify_items, 50):
-                save_items_callback(self, chunk)
-        else:
+        if not spotify_items:
             logger.info('No valid Spotify items to add.')
+            return
+
+        for chunk in chunks(spotify_items, 50):
+            save_items_callback(self, chunk)
+
 
 
     def import_likes(self):

--- a/importer.py
+++ b/importer.py
@@ -130,8 +130,12 @@ class Importer:
         for item in items:
             if item.available:
                 try:
-                    spotify_items.append(self._import_item(item))
-                    logger.info('OK')
+                    spotify_id = self._import_item(item)
+                    if spotify_id is not None:
+                        spotify_items.append(spotify_id)
+                        logger.info('OK')
+                    else:
+                        logger.warning('Item ID is None, skipping...')
                 except NotFoundException as exception:
                     not_imported_section.append(exception.item_name)
                     logger.warning('NO')
@@ -139,8 +143,12 @@ class Importer:
                     not_imported_section.append(item.title)
                     logger.warning('NO')
 
-        for chunk in chunks(spotify_items, 50):
-            save_items_callback(self, chunk)
+        if spotify_items:
+            for chunk in chunks(spotify_items, 50):
+                save_items_callback(self, chunk)
+        else:
+            logger.info('No valid Spotify items to add.')
+
 
     def import_likes(self):
         self.not_imported['Likes'] = []


### PR DESCRIPTION
When running, I sometimes get the following error in the middle of copying process:
```
Traceback (most recent call last):
  File "/Users/oleg/Downloads/yandex2spotify-master/importer.py", line 256, in <module>
    Importer(spotify_client_, yandex_client_, arguments.ignore, arguments.strict_artists_search).import_all()
  File "/Users/oleg/Downloads/yandex2spotify-master/importer.py", line 213, in import_all
    item()
  File "/Users/oleg/Downloads/yandex2spotify-master/importer.py", line 152, in import_likes
    self._add_items_to_spotify(tracks, self.not_imported['Likes'], save_tracks_callback)
  File "/Users/oleg/Downloads/yandex2spotify-master/importer.py", line 138, in _add_items_to_spotify
    save_items_callback(self, chunk)
  File "/Users/oleg/Downloads/yandex2spotify-master/importer.py", line 149, in save_tracks_callback
    handle_spotify_exception(importer.spotify_client.current_user_saved_tracks_add)(spotify_tracks)
  File "/Users/oleg/Downloads/yandex2spotify-master/importer.py", line 44, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/spotipy/client.py", line 902, in current_user_saved_tracks_add
    tlist = [self._get_id("track", t) for t in tracks]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/spotipy/client.py", line 902, in <listcomp>
    tlist = [self._get_id("track", t) for t in tracks]
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/spotipy/client.py", line 1467, in _get_id
    fields = id.split(":")
             ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
```


Modified **_add_items_to_spotify** method in your Importer class to filter out **None** values before they are passed to **current_user_saved_tracks_add**, which fixed the error and the process no longer stops when copying.

