### PR TITLE
Remove must-present albumId condition

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -187,7 +187,7 @@ class Importer:
             if not playlist.collective:
                 tracks = [track.track for track in playlist_tracks]
             elif playlist.collective and playlist_tracks:
-                tracks = self.yandex_client.tracks([track.track_id for track in playlist_tracks if track.album_id])
+                tracks = self.yandex_client.tracks([track.track_id for track in playlist_tracks])
             else:
                 tracks = []
 


### PR DESCRIPTION
So I had the problem with importing this [playlist](https://music.yandex.ru/users/qpr.t/playlists/1003) using the importer script. I debugged it a little and it seems to me that `if track.album_id` condition drops all tracks from that playlist for some reason (I dunno, maybe the API has changed). So empty playlist is not imported.

It seems to me that the condition is unnecessary, maybe it should be dropped as this PR suggests.